### PR TITLE
Synchronise pop operation for unconfirmed publications

### DIFF
--- a/rabbitmq/src/main/scala/com/itv/bucky/Publisher.scala
+++ b/rabbitmq/src/main/scala/com/itv/bucky/Publisher.scala
@@ -66,13 +66,15 @@ object Publisher extends StrictLogging {
       }
 
     private def pop(deliveryTag: Long, multiple: Boolean) =
-      if (multiple) {
-        val entries       = unconfirmedPublications.headMap(deliveryTag + 1L)
-        val removedValues = entries.values().asScala.toList
-        entries.clear()
-        removedValues.flatten
-      } else {
-        Option(unconfirmedPublications.remove(deliveryTag)).toList.flatten
+      unconfirmedPublications.synchronized {
+        if (multiple) {
+          val entries       = unconfirmedPublications.headMap(deliveryTag + 1L)
+          val removedValues = entries.values().asScala.toList
+          entries.clear()
+          removedValues.flatten
+        } else {
+          Option(unconfirmedPublications.remove(deliveryTag)).toList.flatten
+        }
       }
 
   }


### PR DESCRIPTION
Hello, ran in to this exception at runtime, I think it just needs some synchronization:

```
13:00:43.225 [AMQP Connection 10.206.142.125:5672] ERROR c.r.c.i.ForgivingExceptionHandler - ConfirmListener.handle{N,A}ck threw an exception for channel AMQChannel(amqp://oasvc@10.206.142.125:5672/,1)
java.util.ConcurrentModificationException: null
        at java.util.TreeMap$NavigableSubMap$SubMapIterator.nextEntry(TreeMap.java:1703)
        at java.util.TreeMap$NavigableSubMap$SubMapEntryIterator.next(TreeMap.java:1751)
        at java.util.TreeMap$NavigableSubMap$SubMapEntryIterator.next(TreeMap.java:1745)
        at java.util.AbstractMap$2$1.next(AbstractMap.java:418)
        at scala.collection.convert.Wrappers$JIteratorWrapper.next(Wrappers.scala:40)
        at scala.collection.Iterator.foreach(Iterator.scala:929)
        at scala.collection.Iterator.foreach$(Iterator.scala:929)
        at scala.collection.AbstractIterator.foreach(Iterator.scala:1406)
        at scala.collection.IterableLike.foreach(IterableLike.scala:71)
        at scala.collection.IterableLike.foreach$(IterableLike.scala:70)
        at scala.collection.AbstractIterable.foreach(Iterable.scala:54)
        at scala.collection.generic.Growable.$plus$plus$eq(Growable.scala:59)
        at scala.collection.generic.Growable.$plus$plus$eq$(Growable.scala:50)
        at scala.collection.mutable.ListBuffer.$plus$plus$eq(ListBuffer.scala:182)
        at scala.collection.mutable.ListBuffer.$plus$plus$eq(ListBuffer.scala:44)
        at scala.collection.TraversableLike.to(TraversableLike.scala:590)
        at scala.collection.TraversableLike.to$(TraversableLike.scala:587)
        at scala.collection.AbstractTraversable.to(Traversable.scala:104)
        at scala.collection.TraversableOnce.toList(TraversableOnce.scala:294)
        at scala.collection.TraversableOnce.toList$(TraversableOnce.scala:294)
        at scala.collection.AbstractTraversable.toList(Traversable.scala:104)
        at com.itv.bucky.Publisher$PendingConfirmations.pop(Publisher.scala:63)
        at com.itv.bucky.Publisher$PendingConfirmations.completeConfirmation(Publisher.scala:42)
        at com.itv.bucky.Publisher$$anon$1.handleAck(Publisher.scala:80)
        at com.rabbitmq.client.impl.ChannelN.callConfirmListeners(ChannelN.java:485)
        at com.rabbitmq.client.impl.ChannelN.processAsync(ChannelN.java:360)
        at com.rabbitmq.client.impl.AMQChannel.handleCompleteInboundCommand(AMQChannel.java:143)
        at com.rabbitmq.client.impl.AMQChannel.handleFrame(AMQChannel.java:90)
        at com.rabbitmq.client.impl.AMQConnection.readFrame(AMQConnection.java:634)
        at com.rabbitmq.client.impl.AMQConnection.access$300(AMQConnection.java:47)
        at com.rabbitmq.client.impl.AMQConnection$MainLoop.run(AMQConnection.java:572)
        at java.lang.Thread.run(Thread.java:748)
```