### PR TITLE
Adding a function for the final failure when requeuing

### DIFF
--- a/core/src/main/scala/com/itv/bucky/DeliveryUnmarshalHandler.scala
+++ b/core/src/main/scala/com/itv/bucky/DeliveryUnmarshalHandler.scala
@@ -17,3 +17,14 @@ class DeliveryUnmarshalHandler[F[_], T, S](unmarshaller: DeliveryUnmarshaller[T]
       F.apply(deserializationFailureAction)
   }
 }
+
+class UnmarshalFailureAction[F[_], T](unmarshaller: DeliveryUnmarshaller[T])(implicit F: Monad[F]) extends StrictLogging {
+  def apply(f: T => F[Unit])(delivery: Delivery): F[Unit] = {
+    unmarshaller.unmarshal(delivery) match {
+      case UnmarshalResult.Success(message) => f(message)
+      case UnmarshalResult.Failure(reason, throwable) =>
+      logger.error(s"Cannot deserialize: ${delivery.body} because: '$reason'", throwable)
+      F.apply(())
+    }
+  }
+}


### PR DESCRIPTION
Hey people,

We have a need to publish a message when a message has Deadlettered, but this became tricky when we were Requeuing. This PR allows us to pass in a function that will only be used when the retry for a Requeues meesage has run out, and the message will be Deadlettered. 

Thanks!