### PR TITLE
Add channel shutdown listener for logging

### DIFF
--- a/rabbitmq/src/main/scala/com/itv/bucky/Connection.scala
+++ b/rabbitmq/src/main/scala/com/itv/bucky/Connection.scala
@@ -74,7 +74,13 @@ object Channel extends StrictLogging {
   def apply(connection: RabbitConnection): Id[RabbitChannel] =
     Try {
       logger.info(s"Starting Channel")
-      connection.createChannel()
+      val channel = connection.createChannel()
+      channel.addShutdownListener( (cause: ShutdownSignalException) =>
+        logger.info(s"Channel shut down, cause reason: ${cause.getReason.protocolMethodName()}, " +
+          s"is hard error: ${cause.isHardError}, is initiated by application: ${cause.isInitiatedByApplication}",
+          cause.getStackTrace)
+      )
+      channel
     } match {
       case Success(channel) =>
         logger.info(s"Channel has been started successfully!")


### PR DESCRIPTION
We'd like to see logs when the channel is shut down so we can see the cause

Co-authored-by: Alexander Worton <alexander.worton@itv.com>