### PR TITLE
Declare deadletter, requeue, and redeliver exchanges as Topic

### DIFF
--- a/core/src/main/scala/com/itv/bucky/pattern/requeue/package.scala
+++ b/core/src/main/scala/com/itv/bucky/pattern/requeue/package.scala
@@ -17,7 +17,7 @@ package object requeue {
 
     requeueDeclarations(queueName,
                         RoutingKey(queueName.value),
-                        Exchange(dlxExchangeName).binding(RoutingKey(queueName.value) -> deadLetterQueueName),
+                        Exchange(dlxExchangeName, exchangeType = Topic).binding(RoutingKey(queueName.value) -> deadLetterQueueName),
                         retryAfter)
   }
 
@@ -38,8 +38,8 @@ package object requeue {
       Queue(deadLetterQueueName),
       Queue(requeueQueueName).deadLetterExchange(redeliverExchangeName).messageTTL(retryAfter),
       deadletterExchange.binding(routingKey              -> deadLetterQueueName),
-      Exchange(requeueExchangeName).binding(routingKey   -> requeueQueueName),
-      Exchange(redeliverExchangeName).binding(routingKey -> queueName)
+      Exchange(requeueExchangeName, exchangeType = Topic).binding(routingKey   -> requeueQueueName),
+      Exchange(redeliverExchangeName, exchangeType = Topic).binding(routingKey -> queueName)
     )
   }
 


### PR DESCRIPTION
Bucky declares the exchanges required for the requeue pattern as Direct type.
That means if the routing key used by a queue uses a wildcard, it will
not be able to route requeues or dead letters and they will be lost into
the ether :scream:

So the solution seems to be to use the Topic exchange type for these
exchanges. However this is quite a breaking change as existing exchanges
will have to be deleted to be redeclared. Not an easy one to roll out.