### PR TITLE
log message publish/receive as INFO

### DIFF
--- a/rabbitmq/src/main/scala/com/itv/bucky/ChannelPublisher.scala
+++ b/rabbitmq/src/main/scala/com/itv/bucky/ChannelPublisher.scala
@@ -16,7 +16,7 @@ class ChannelPublisher private (channel: Channel) extends StrictLogging {
     channel.synchronized {
       logger.debug(s"Acquire the channel: $channel")
       val deliveryTag = channel.getNextPublishSeqNo
-      logger.debug("Publishing with delivery tag {}L to {}:{} with {}: {}",
+      logger.info("Publishing with delivery tag {}L to {}:{} with {}: {}",
                    box(deliveryTag),
                    cmd.exchange,
                    cmd.routingKey,

--- a/rabbitmq/src/main/scala/com/itv/bucky/Consumer.scala
+++ b/rabbitmq/src/main/scala/com/itv/bucky/Consumer.scala
@@ -45,13 +45,13 @@ object Consumer extends StrictLogging {
                                actionOnFailure: ConsumeAction,
                                delivery: Delivery)(implicit F: MonadError[F, E]) =
     F.map {
-      logger.debug("Received {} on {}", delivery, queueName)
+      logger.info("Received {} on {}", delivery, queueName)
       F.handleError(F.flatMap(F.apply(handler(delivery)))(identity)) { error =>
         logger.error(s"Unhandled exception processing delivery ${delivery.envelope.deliveryTag}L on $queueName", error)
         F.apply(actionOnFailure)
       }
     } { action =>
-      logger.debug("Responding with {} to {} on {}", action, delivery, queueName)
+      logger.info("Responding with {} to {} on {}", action, delivery, queueName)
       action match {
         case Ack                => channel.basicAck(delivery.envelope.deliveryTag, false)
         case DeadLetter         => channel.basicNack(delivery.envelope.deliveryTag, false, false)

--- a/scalaz/src/main/scala/com/itv/bucky/taskz/TaskAmqpClient.scala
+++ b/scalaz/src/main/scala/com/itv/bucky/taskz/TaskAmqpClient.scala
@@ -107,7 +107,7 @@ case class TaskAmqpClient(channel: Id[RabbitChannel])(implicit pool: ExecutorSer
       logger.debug(s"Acquire the channel: $channel")
       val deliveryTag = channel.getNextPublishSeqNo
 
-      logger.debug("Publishing with delivery tag {}L to {}:{} with {}: {}",
+      logger.info("Publishing with delivery tag {}L to {}:{} with {}: {}",
                    ChannelPublisher.box(deliveryTag),
                    cmd.exchange,
                    cmd.routingKey,

--- a/test/src/main/scala/com/itv/bucky/RabbitSimulator.scala
+++ b/test/src/main/scala/com/itv/bucky/RabbitSimulator.scala
@@ -74,7 +74,7 @@ class RabbitSimulator[B[_]](bindings: Bindings = IdentityBindings)(implicit M: M
       consumeActionValue.onComplete { _ =>
         val publication = messagesBeingProcessed(key)
         messagesBeingProcessed -= key
-        logger.debug(s"Consume message [${publication.message.unmarshal[String]}] from ${publication.queueName}")
+        logger.info(s"Consume message [${publication.message.unmarshal[String]}] from ${publication.queueName}")
       }
       consumeActionValue
     }
@@ -90,7 +90,7 @@ class RabbitSimulator[B[_]](bindings: Bindings = IdentityBindings)(implicit M: M
     }
 
   def publish(publishCommand: PublishCommand): Future[ConsumeAction] = {
-    logger.debug(
+    logger.info(
       s"Publish message [${publishCommand.body.unmarshal[String]}] with ${publishCommand.exchange} ${publishCommand.routingKey}")
     if (isDefinedAt(publishCommand)) {
       val queueName = queueNameFor(publishCommand)
@@ -164,5 +164,4 @@ object RabbitSimulator {
 
   val stringPublishCommandBuilder  = publishCommandBuilder(StringPayloadMarshaller)
   val defaultPublishCommandBuilder = stringPublishCommandBuilder using ExchangeName("")
-
 }


### PR DESCRIPTION
This was previously set to debug, which often meant that vital information couldn't be searched in Kibana