### PR TITLE
Handler concurrency issue

### DIFF
--- a/core/src/main/scala/com/itv/bucky/AmqpClient.scala
+++ b/core/src/main/scala/com/itv/bucky/AmqpClient.scala
@@ -1,5 +1,8 @@
 package com.itv.bucky
 
+import java.util.Collections
+import java.util.concurrent.{AbstractExecutorService, TimeUnit}
+
 import cats.effect._
 import cats.implicits._
 import com.itv.bucky.consume.{ConsumeAction, DeadLetter, Delivery, PublishCommand}
@@ -7,6 +10,7 @@ import com.rabbitmq.client.{ConnectionFactory, ShutdownListener, ShutdownSignalE
 import com.itv.bucky.decl._
 import com.typesafe.scalalogging.StrictLogging
 
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService}
 import scala.language.higherKinds
 
 trait AmqpClient[F[_]] {
@@ -43,7 +47,7 @@ object AmqpClient extends StrictLogging {
     Resource.make(cs.shift.flatMap(_ => make))(channel => F.delay(channel.close()))
   }
 
-  private def createConnection[F[_]](config: AmqpClientConfig)(implicit F: Sync[F], cs: ContextShift[F]): Resource[F, RabbitConnection] = {
+  private def createConnection[F[_]](config: AmqpClientConfig)(implicit F: Sync[F], cs: ContextShift[F], executionContext: ExecutionContext): Resource[F, RabbitConnection] = {
     val make =
       F.delay {
         logger.info(s"Starting AmqpClient")
@@ -53,6 +57,20 @@ object AmqpClient extends StrictLogging {
         connectionFactory.setUsername(config.username)
         connectionFactory.setPassword(config.password)
         connectionFactory.setAutomaticRecoveryEnabled(config.networkRecoveryInterval.isDefined)
+        connectionFactory.setSharedExecutor(executionContext match {
+          case null => throw null
+          case eces: ExecutionContextExecutorService => eces
+          case other => new AbstractExecutorService with ExecutionContextExecutorService {
+            override def prepare(): ExecutionContext = other
+            override def isShutdown = false
+            override def isTerminated = false
+            override def shutdown() = ()
+            override def shutdownNow() = Collections.emptyList[Runnable]
+            override def execute(runnable: Runnable): Unit = other execute runnable
+            override def reportFailure(t: Throwable): Unit = other reportFailure t
+            override def awaitTermination(length: Long,unit: TimeUnit): Boolean = false
+          }
+        })
         config.networkRecoveryInterval.map(_.toMillis.toInt).foreach(connectionFactory.setNetworkRecoveryInterval)
         config.virtualHost.foreach(connectionFactory.setVirtualHost)
         connectionFactory.newConnection()
@@ -69,7 +87,7 @@ object AmqpClient extends StrictLogging {
     Resource.make(cs.shift.flatMap(_ => make))(connection => F.delay(connection.close()))
   }
 
-  def apply[F[_]](config: AmqpClientConfig)(implicit F: ConcurrentEffect[F], cs: ContextShift[F], t: Timer[F]): Resource[F, AmqpClient[F]] =
+  def apply[F[_]](config: AmqpClientConfig)(implicit F: ConcurrentEffect[F], cs: ContextShift[F], t: Timer[F], executionContext: ExecutionContext): Resource[F, AmqpClient[F]] =
     for {
       connection <- createConnection(config)
       rabbitChannel = createChannel(connection).map(Channel.apply[F])
@@ -77,7 +95,7 @@ object AmqpClient extends StrictLogging {
     } yield client
 
   def apply[F[_]](config: AmqpClientConfig,
-                  channel: Resource[F, Channel[F]])(implicit F: ConcurrentEffect[F], cs: ContextShift[F], t: Timer[F]): Resource[F, AmqpClient[F]] =
+                  channel: Resource[F, Channel[F]])(implicit F: ConcurrentEffect[F], cs: ContextShift[F], t: Timer[F], executionContext: ExecutionContext): Resource[F, AmqpClient[F]] =
     channel.flatMap { channel =>
       val make =
         for {

--- a/core/src/main/scala/com/itv/bucky/AmqpClientConnectionManager.scala
+++ b/core/src/main/scala/com/itv/bucky/AmqpClientConnectionManager.scala
@@ -1,7 +1,5 @@
 package com.itv.bucky
 
-import java.util.concurrent.Executors
-
 import cats.effect._
 import cats.effect.concurrent.{Deferred, Ref}
 import cats.effect.implicits._
@@ -17,13 +15,13 @@ import scala.language.higherKinds
 import scala.util.Try
 
 private[bucky] case class AmqpClientConnectionManager[F[_]](
-    amqpConfig: AmqpClientConfig,
-    channel: Channel[F],
-    pendingConfirmListener: PendingConfirmListener[F])(implicit F: ConcurrentEffect[F], cs: ContextShift[F], t: Timer[F])
+                                                             amqpConfig: AmqpClientConfig,
+                                                             publishChannel: Channel[F],
+                                                             pendingConfirmListener: PendingConfirmListener[F])(implicit F: ConcurrentEffect[F], cs: ContextShift[F], t: Timer[F])
     extends StrictLogging {
 
   private def runWithChannelSync[T](action: F[T]): F[T] =
-    channel.synchroniseIfNeeded {
+    publishChannel.synchroniseIfNeeded {
       F.fromTry(Try {
         action.toIO.unsafeRunSync()
       })
@@ -37,10 +35,10 @@ private[bucky] case class AmqpClientConnectionManager[F[_]](
         signal <- Deferred[F, Boolean]
         _ <- runWithChannelSync {
           for {
-            nextPublishSeq <- channel.getNextPublishSeqNo
+            nextPublishSeq <- publishChannel.getNextPublishSeqNo
             _              <- deliveryTag.set(Some(nextPublishSeq))
             _              <- pendingConfirmListener.pendingConfirmations.update(_ + (nextPublishSeq -> signal))
-            _              <- channel.publish(cmd)
+            _              <- publishChannel.publish(cmd)
           } yield ()
         }
         _ <- signal.get.ifM(F.unit, F.raiseError[Unit](new RuntimeException("Failed to publish msg.")))
@@ -59,7 +57,7 @@ private[bucky] case class AmqpClientConnectionManager[F[_]](
         }
     } yield ()
 
-  def registerConsumer(queueName: QueueName, handler: Handler[F, Delivery], onFailure: ConsumeAction): F[Unit] =
+  def registerConsumer(channel: Channel[F], queueName: QueueName, handler: Handler[F, Delivery], onFailure: ConsumeAction): F[Unit] =
     for {
       _ <- cs.shift
       consumerTag <- F.delay(ConsumerTag.create(queueName))
@@ -70,17 +68,17 @@ private[bucky] case class AmqpClientConnectionManager[F[_]](
       _ <- F.delay(logger.debug("Successfully registered consumer for queue: {} with tag.", queueName.value), consumerTag.value)
     } yield ()
 
-  def declare(declarations: Iterable[Declaration]): F[Unit] = channel.runDeclarations(declarations)
+  def declare(declarations: Iterable[Declaration]): F[Unit] = publishChannel.runDeclarations(declarations)
 }
 
 private[bucky] object AmqpClientConnectionManager extends StrictLogging {
 
   def apply[F[_]](config: AmqpClientConfig,
-                  channel: Channel[F])(implicit F: ConcurrentEffect[F], cs: ContextShift[F], t: Timer[F]): F[AmqpClientConnectionManager[F]] =
+                  publishChannel: Channel[F])(implicit F: ConcurrentEffect[F], cs: ContextShift[F], t: Timer[F]): F[AmqpClientConnectionManager[F]] =
     for {
       pendingConfirmations <- Ref.of[F, TreeMap[Long, Deferred[F, Boolean]]](TreeMap.empty)
-      _                    <- channel.confirmSelect
+      _                    <- publishChannel.confirmSelect
       confirmListener      <- F.delay(publish.PendingConfirmListener(pendingConfirmations))
-      _                    <- channel.addConfirmListener(confirmListener)
-    } yield AmqpClientConnectionManager(config, channel, confirmListener)
+      _                    <- publishChannel.addConfirmListener(confirmListener)
+    } yield AmqpClientConnectionManager(config, publishChannel, confirmListener)
 }

--- a/core/src/main/scala/com/itv/bucky/LoggingAmqpClient.scala
+++ b/core/src/main/scala/com/itv/bucky/LoggingAmqpClient.scala
@@ -1,6 +1,6 @@
 package com.itv.bucky
 
-import cats.effect.ConcurrentEffect
+import cats.effect.{ConcurrentEffect, Resource}
 import com.typesafe.scalalogging.StrictLogging
 import cats._
 import cats.implicits._
@@ -42,7 +42,7 @@ object LoggingAmqpClient extends StrictLogging {
           }
       }
 
-      override def registerConsumer(queueName: QueueName, handler: Handler[F, Delivery], exceptionalAction: ConsumeAction): F[Unit] = {
+      override def registerConsumer(queueName: QueueName, handler: Handler[F, Delivery], exceptionalAction: ConsumeAction): Resource[F, Unit] = {
         val newHandler = (delivery: Delivery) => {
           (for {
             result <- handler(delivery).attempt

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,7 @@
 ### Getting Started
 
 In order to get started with bucky, add the following to you `build.sbt`:
+
  
 ```scala 
 val buckyVersion = "2.0.0-M5"

--- a/example/src/main/scala/com/itv/bucky/example/marshalling/MarshallingPublisher.scala
+++ b/example/src/main/scala/com/itv/bucky/example/marshalling/MarshallingPublisher.scala
@@ -10,6 +10,8 @@ import com.typesafe.config.ConfigFactory
 import scala.concurrent._
 import scala.concurrent.duration._
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 
 object MarshallingPublisher extends IOApp {
   import com.itv.bucky._

--- a/example/src/main/scala/com/itv/bucky/example/marshalling/UnmarshallingConsumer.scala
+++ b/example/src/main/scala/com/itv/bucky/example/marshalling/UnmarshallingConsumer.scala
@@ -1,15 +1,17 @@
 package com.itv.bucky.example.marshalling
 
-import cats.effect.{ExitCode, IO, IOApp}
+import cats.effect.{ExitCode, IO, IOApp, Resource}
 import com.itv.bucky.Unmarshaller.StringPayloadUnmarshaller
 import com.itv.bucky._
 import com.itv.bucky.consume._
 import com.itv.bucky.decl._
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.StrictLogging
+import cats.effect._
+import cats.implicits._
 
 import scala.concurrent.ExecutionContext.Implicits.global
-/*
+
 object UnmarshallingConsumer extends IOApp with StrictLogging {
 
   //start snippet 1
@@ -52,12 +54,11 @@ object UnmarshallingConsumer extends IOApp with StrictLogging {
 
   //start snippet 4
   override def run(args: List[String]): IO[ExitCode] =
-    AmqpClient[IO](amqpClientConfig).use { amqpClient =>
-      for {
-        _ <- amqpClient.declare(Declarations.all)
+      (for {
+        amqpClient <- AmqpClient[IO](amqpClientConfig)
+        _ <- Resource.liftF(amqpClient.declare(Declarations.all))
         _ <- amqpClient.registerConsumerOf(Declarations.queue.name, personHandler)
-      } yield ExitCode.Success
-    }
+      } yield ()).use(_ => IO.never *> IO.delay(ExitCode.Success))
   //end snippet 4
 
-}*/
+}

--- a/example/src/main/scala/com/itv/bucky/example/marshalling/UnmarshallingConsumer.scala
+++ b/example/src/main/scala/com/itv/bucky/example/marshalling/UnmarshallingConsumer.scala
@@ -9,7 +9,7 @@ import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.StrictLogging
 
 import scala.concurrent.ExecutionContext.Implicits.global
-
+/*
 object UnmarshallingConsumer extends IOApp with StrictLogging {
 
   //start snippet 1
@@ -60,4 +60,4 @@ object UnmarshallingConsumer extends IOApp with StrictLogging {
     }
   //end snippet 4
 
-}
+}*/

--- a/example/src/main/scala/com/itv/bucky/example/marshalling/UnmarshallingConsumer.scala
+++ b/example/src/main/scala/com/itv/bucky/example/marshalling/UnmarshallingConsumer.scala
@@ -8,6 +8,8 @@ import com.itv.bucky.decl._
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.StrictLogging
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 object UnmarshallingConsumer extends IOApp with StrictLogging {
 
   //start snippet 1

--- a/example/src/main/scala/com/itv/bucky/example/requeue/RequeueConsumer.scala
+++ b/example/src/main/scala/com/itv/bucky/example/requeue/RequeueConsumer.scala
@@ -1,10 +1,10 @@
 package com.itv.bucky.example.requeue
 
-import cats.effect.{ExitCode, IO, IOApp}
+import cats.effect.{ExitCode, IO, IOApp, Resource}
 import com.itv.bucky.Unmarshaller.StringPayloadUnmarshaller
 import com.itv.bucky.decl._
 import com.itv.bucky._
-import com.itv.bucky.consume.{_}
+import com.itv.bucky.consume._
 import com.itv.bucky.pattern.requeue._
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.StrictLogging
@@ -12,7 +12,10 @@ import com.typesafe.scalalogging.StrictLogging
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
-/*object RequeueConsumer extends IOApp with StrictLogging {
+import cats.effect._
+import cats.implicits._
+
+object RequeueConsumer extends IOApp with StrictLogging {
 
   object Declarations {
     val queue = Queue(QueueName(s"requeue_string-1"))
@@ -36,11 +39,10 @@ import scala.concurrent.duration._
     }
 
   override def run(args: List[String]): IO[ExitCode] =
-    AmqpClient[IO](amqpClientConfig).use { amqpClient =>
-      for {
-        _ <- amqpClient.declare(Declarations.all)
+    (for {
+        amqpClient <- AmqpClient[IO](amqpClientConfig)
+        _ <- Resource.liftF(amqpClient.declare(Declarations.all))
         _ <- amqpClient.registerRequeueConsumerOf(Declarations.queue.name,
           stringToLogRequeueHandler)
-      } yield ExitCode.Success
-    }
-}*/
+      } yield ()).use(_ => IO.never *> IO(ExitCode.Success))
+}

--- a/example/src/main/scala/com/itv/bucky/example/requeue/RequeueConsumer.scala
+++ b/example/src/main/scala/com/itv/bucky/example/requeue/RequeueConsumer.scala
@@ -12,7 +12,7 @@ import com.typesafe.scalalogging.StrictLogging
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
-object RequeueConsumer extends IOApp with StrictLogging {
+/*object RequeueConsumer extends IOApp with StrictLogging {
 
   object Declarations {
     val queue = Queue(QueueName(s"requeue_string-1"))
@@ -43,4 +43,4 @@ object RequeueConsumer extends IOApp with StrictLogging {
           stringToLogRequeueHandler)
       } yield ExitCode.Success
     }
-}
+}*/

--- a/kamon/src/main/scala/com/itv/bucky/kamonSupport/KamonSupport.scala
+++ b/kamon/src/main/scala/com/itv/bucky/kamonSupport/KamonSupport.scala
@@ -1,7 +1,7 @@
 package com.itv.bucky.kamonSupport
 import java.time.Instant
 
-import cats.effect.{ConcurrentEffect, ContextShift, Timer}
+import cats.effect.{ConcurrentEffect, Resource}
 import com.itv.bucky.consume._
 import com.itv.bucky.{AmqpClient, Handler, Publisher, QueueName, decl}
 import cats.implicits._
@@ -73,7 +73,7 @@ object KamonSupport {
           .map { case (key, value) => (key, value) }
           .toMap[String, AnyRef]
 
-      override def registerConsumer(queueName: QueueName, handler: Handler[F, Delivery], exceptionalAction: ConsumeAction): F[Unit] = {
+      override def registerConsumer(queueName: QueueName, handler: Handler[F, Delivery], exceptionalAction: ConsumeAction): Resource[F, Unit] = {
         val newHandler = (delivery: Delivery) => {
           (for {
             start       <- F.delay(Kamon.clock().instant())

--- a/kamon/src/test/scala/com/itv/bucky/kamonSupport/KamonSupportTest.scala
+++ b/kamon/src/test/scala/com/itv/bucky/kamonSupport/KamonSupportTest.scala
@@ -25,7 +25,7 @@ import kamon.trace.Span.TagValue
 import kamon.trace.{IdentityProvider, Span}
 
 class KamonSupportTest extends FunSuite with Matchers with Eventually with SpanSupport {
-  val queue = Queue(QueueName("kamon-spec-test"))
+  /*val queue = Queue(QueueName("kamon-spec-test"))
   val rk    = RoutingKey("kamon-spec-rk")
   val exchange = Exchange(ExchangeName("kamon-spec-exchange"))
     .binding(rk -> queue.name)
@@ -155,5 +155,5 @@ class KamonSupportTest extends FunSuite with Matchers with Eventually with SpanS
       case boolean: TagValue.Boolean => s"${boolean.text}"
       case TagValue.String(string)   => s"$string"
       case TagValue.Number(number)   => s"$number"
-    }
+    }*/
 }

--- a/test/src/main/scala/com/itv/bucky/test/package.scala
+++ b/test/src/main/scala/com/itv/bucky/test/package.scala
@@ -89,6 +89,7 @@ package object test {
     def client(channel: StubChannel[F], config: AmqpClientConfig): Resource[F, AmqpClient[F]] =
       AmqpClient[F](
         config,
+        () => Resource.pure[F, Channel[F]](channel),
         Resource.pure[F, Channel[F]](channel)
       )
 

--- a/test/src/main/scala/com/itv/bucky/test/package.scala
+++ b/test/src/main/scala/com/itv/bucky/test/package.scala
@@ -62,18 +62,20 @@ package object test {
   }
 
   trait IOAmqpClientTest extends AmqpClientTest[IO] {
-    implicit val globalExecutionContext: ExecutionContext = ExecutionContext.Implicits.global
+    val globalExecutionContext: ExecutionContext = ExecutionContext.Implicits.global
+    override implicit val ec: ExecutionContext = globalExecutionContext
     override implicit val timer: Timer[IO] = IO.timer(globalExecutionContext)
     override implicit val contextShift: ContextShift[IO] = IO.contextShift(globalExecutionContext)
     override implicit val F: ConcurrentEffect[IO] = IO.ioConcurrentEffect(contextShift)
   }
 
   object AmqpClientTest {
-    def apply[F[_]](implicit concurrentEffect: ConcurrentEffect[F], t: Timer[F], cs: ContextShift[F]): AmqpClientTest[F] =
+    def apply[F[_]](implicit concurrentEffect: ConcurrentEffect[F], t: Timer[F], cs: ContextShift[F], executionContext: ExecutionContext): AmqpClientTest[F] =
       new AmqpClientTest[F]() {
         override implicit val F: ConcurrentEffect[F] = concurrentEffect
         override implicit val timer: Timer[F] = t
         override implicit val contextShift: ContextShift[F] = cs
+        override implicit val ec: ExecutionContext = executionContext
       }
   }
 
@@ -82,6 +84,7 @@ package object test {
     implicit val F: ConcurrentEffect[F]
     implicit val timer: Timer[F]
     implicit val contextShift: ContextShift[F]
+    implicit val ec: ExecutionContext
 
     def client(channel: StubChannel[F], config: AmqpClientConfig): Resource[F, AmqpClient[F]] =
       AmqpClient[F](

--- a/test/src/main/scala/com/itv/bucky/test/stubs/StubChannel.scala
+++ b/test/src/main/scala/com/itv/bucky/test/stubs/StubChannel.scala
@@ -76,7 +76,7 @@ abstract class StubChannel[F[_]](implicit F: ConcurrentEffect[F]) extends Channe
   override def sendAction(action: ConsumeAction)(envelope: bucky.Envelope): F[Unit] =
     F.unit
 
-  override def registerConsumer(handler: Handler[F, Delivery], onFailure: ConsumeAction, queue: QueueName, consumerTag: ConsumerTag): F[Unit] =
+  override def registerConsumer(handler: Handler[F, Delivery], onFailure: ConsumeAction, queue: QueueName, consumerTag: ConsumerTag, cs: ContextShift[F]): F[Unit] =
     F.delay(handlers.synchronized(handlers.put(queue, handler -> onFailure))).void
 
   override def addConfirmListener(listener: ConfirmListener): F[Unit] = F.delay(confirmListeners.synchronized(confirmListeners += listener))

--- a/test/src/test/scala/com/itv/bucky/test/StubTest.scala
+++ b/test/src/test/scala/com/itv/bucky/test/StubTest.scala
@@ -22,7 +22,7 @@ class StubTest extends FunSuite with Matchers with IOAmqpClientTest {
       Resource.liftF(client.declare(declarations)).flatMap(_ => client.registerConsumerOf(queue, consumer)).use { _ =>
         for {
           publisher <- IO(client.publisherOf[String](exchange, rk))
-          _ <- (1 to 10).toList.map(_ => publisher(message)).sequence
+          _         <- (1 to 10).toList.map(_ => publisher(message)).sequence
         } yield {
           all(consumer.receivedMessages) should be(message)
           all(consumer.returnedResults) should be(Right(Ack))
@@ -39,10 +39,15 @@ class StubTest extends FunSuite with Matchers with IOAmqpClientTest {
           publisher("publish from handler").map(_ => Ack)
       }
 
-      Resource.liftF(client.declare(declarations)).flatMap { _ => client.registerConsumerOf(queue, handler) }.use { _ =>
-        val publisher = client.publisherOf[String] (exchange, rk)
-        publisher(message)
-      }
+      Resource
+        .liftF(client.declare(declarations))
+        .flatMap { _ =>
+          client.registerConsumerOf(queue, handler)
+        }
+        .use { _ =>
+          val publisher = client.publisherOf[String](exchange, rk)
+          publisher(message)
+        }
     }
   }
 
@@ -53,130 +58,154 @@ class StubTest extends FunSuite with Matchers with IOAmqpClientTest {
         override def apply(delivery: String): IO[consume.ConsumeAction] =
           stubPubslisher(delivery).map(_ => Ack)
       }
-
-      for {
-        _         <- client.declare(declarations)
-        consumer  = handler
-        _         <- client.registerConsumerOf(queue, consumer)
-        publisher = client.publisherOf[String](exchange, rk)
-        _         <- publisher(message)
-      } yield {
-        stubPubslisher.recordedMessages shouldBe List(message)
-      }
+      (for {
+        _ <- Resource.liftF(client.declare(declarations))
+        _ <- client.registerConsumerOf(queue, handler)
+      } yield ())
+        .use { _ =>
+          for {
+            publisher <- IO(client.publisherOf[String](exchange, rk))
+            _         <- publisher(message)
+          } yield stubPubslisher.recordedMessages shouldBe List(message)
+        }
     }
   }
 
   test("Multiple Recording Handlers can be registered") {
+    val consumer1 = StubHandlers.ackHandler[IO, String]
+    val consumer2 = StubHandlers.ackHandler[IO, String]
+    val queue2    = QueueName("queue2")
     runAmqpTestAllAck { client =>
-      val queue2 = QueueName("queue2")
-      for {
-        _         <- client.declare(declarations ++ List(Queue(queue2), Exchange(exchange).binding(rk -> queue2)))
-        consumer1 <- IO.pure(StubHandlers.ackHandler[IO, String])
-        consumer2 <- IO.pure(StubHandlers.ackHandler[IO, String])
-        _         <- client.registerConsumerOf(queue, consumer1)
-        _         <- client.registerConsumerOf(queue2, consumer2)
-        publisher <- IO(client.publisherOf[String](exchange, rk))
-        _         <- (1 to 10).toList.map(_ => publisher(message)).sequence
-      } yield {
-        all(consumer1.receivedMessages) should be(message)
-        all(consumer1.returnedResults) should be(Right(Ack))
-
-        all(consumer2.receivedMessages) should be(message)
-        all(consumer2.returnedResults) should be(Right(Ack))
+      (for {
+        _ <- Resource.liftF(client.declare(declarations ++ List(Queue(queue2), Exchange(exchange).binding(rk -> queue2))))
+        _ <- client.registerConsumerOf(queue, consumer1)
+        _ <- client.registerConsumerOf(queue2, consumer2)
+      } yield ()).use { _ =>
+        for {
+          publisher <- IO(client.publisherOf[String](exchange, rk))
+          _         <- (1 to 10).toList.map(_ => publisher(message)).sequence
+        } yield {
+          all(consumer1.receivedMessages) should be(message)
+          all(consumer1.returnedResults) should be(Right(Ack))
+          all(consumer2.receivedMessages) should be(message)
+          all(consumer2.returnedResults) should be(Right(Ack))
+        }
       }
     }
   }
 
   test("An all shall ack client should fail to publish if a handler doesn't return an Ack") {
+    val consumer = StubHandlers.deadLetterHandler[IO, String]
     runAmqpTestAllAck { client =>
-      for {
-        _          <- client.declare(declarations)
-        consumer   <- IO.pure(StubHandlers.deadLetterHandler[IO, String])
-        _          <- client.registerConsumerOf(queue, consumer)
-        publisher  <- IO(client.publisherOf[String](exchange, rk))
-        publishRes <- publisher(message).attempt
-      } yield {
-        consumer.receivedMessages shouldBe List(message)
-        publishRes shouldBe 'left
+      (for {
+        _ <- Resource.liftF(client.declare(declarations))
+        _ <- client.registerConsumerOf(queue, consumer)
+      } yield ()).use { _ =>
+        for {
+          publisher  <- IO(client.publisherOf[String](exchange, rk))
+          publishRes <- publisher(message).attempt
+        } yield {
+          consumer.receivedMessages shouldBe List(message)
+          publishRes shouldBe 'left
+        }
+
       }
     }
   }
 
   test("An all shall ack client should fail to publish if a handler returns an exception") {
+    val consumer = StubHandlers.recordingHandler[IO, String](_ => IO.raiseError(exception))
     runAmqpTestAllAck { client =>
-      for {
-        _          <- client.declare(declarations)
-        consumer   <- IO.pure(StubHandlers.recordingHandler[IO, String](_ => IO.raiseError(exception)))
-        _          <- client.registerConsumerOf(queue, consumer)
-        publisher  <- IO(client.publisherOf[String](exchange, rk))
-        publishRes <- publisher(message).attempt
-      } yield {
-        consumer.receivedMessages shouldBe List(message)
-        consumer.returnedResults shouldBe List(Left(exception))
-        publishRes shouldBe 'left
+      (for {
+        _ <- Resource.liftF(client.declare(declarations))
+        _ <- client.registerConsumerOf(queue, consumer)
+      } yield ()).use { _ =>
+        for {
+          publisher  <- IO(client.publisherOf[String](exchange, rk))
+          publishRes <- publisher(message).attempt
+        } yield {
+          consumer.receivedMessages shouldBe List(message)
+          consumer.returnedResults shouldBe List(Left(exception))
+          publishRes shouldBe 'left
+        }
       }
     }
   }
 
   test("Forgiving client should not fail to publish if a handler doesn't return an Ack") {
+    val consumer = StubHandlers.deadLetterHandler[IO, String]
     runAmqpTestForgiving { client =>
-      for {
-        _          <- client.declare(declarations)
-        consumer   <- IO.pure(StubHandlers.deadLetterHandler[IO, String])
-        _          <- client.registerConsumerOf(queue, consumer)
-        publisher  <- IO(client.publisherOf[String](exchange, rk))
-        publishRes <- publisher(message).attempt
-      } yield {
-        consumer.receivedMessages shouldBe List(message)
-        publishRes shouldBe 'right
+      (for {
+        _ <- Resource.liftF(client.declare(declarations))
+        _ <- client.registerConsumerOf(queue, consumer)
+      } yield ()).use { _ =>
+        for {
+          publisher  <- IO(client.publisherOf[String](exchange, rk))
+          publishRes <- publisher(message).attempt
+        } yield {
+          consumer.receivedMessages shouldBe List(message)
+          publishRes shouldBe 'right
+        }
       }
     }
   }
 
   test("Forgiving client should not fail to publish if a handler returns an exception") {
+    val consumer = StubHandlers.recordingHandler[IO, String](_ => IO.raiseError(exception))
     runAmqpTestForgiving { client =>
-      for {
-        _          <- client.declare(declarations)
-        consumer   <- IO.pure(StubHandlers.recordingHandler[IO, String](_ => IO.raiseError(exception)))
-        _          <- client.registerConsumerOf(queue, consumer)
-        publisher  <- IO(client.publisherOf[String](exchange, rk))
-        publishRes <- publisher(message).attempt
-      } yield {
-        consumer.receivedMessages shouldBe List(message)
-        publishRes shouldBe 'right
+      (for {
+        _ <- Resource.liftF(client.declare(declarations))
+        _ <- client.registerConsumerOf(queue, consumer)
+
+      } yield ()).use { _ =>
+        for {
+          publisher  <- IO(client.publisherOf[String](exchange, rk))
+          publishRes <- publisher(message).attempt
+        } yield {
+          consumer.receivedMessages shouldBe List(message)
+          publishRes shouldBe 'right
+        }
       }
     }
   }
 
   test("An strict simulator client should not fail publish if a handler doesn't return an Ack") {
+    val consumer = StubHandlers.deadLetterHandler[IO, String]
     runAmqpTestStrict { client =>
-      for {
-        _          <- client.declare(declarations)
-        consumer   <- IO.pure(StubHandlers.deadLetterHandler[IO, String])
-        _          <- client.registerConsumerOf(queue, consumer)
-        publisher  <- IO(client.publisherOf[String](exchange, rk))
-        publishRes <- publisher(message).attempt
-      } yield {
-        consumer.receivedMessages shouldBe List(message)
-        consumer.returnedResults shouldBe List(Right(DeadLetter))
-        publishRes shouldBe 'right
+      (for {
+        _ <- Resource.liftF(client.declare(declarations))
+        _ <- client.registerConsumerOf(queue, consumer)
+      } yield ()).use { _ =>
+        for {
+          publisher  <- IO(client.publisherOf[String](exchange, rk))
+          publishRes <- publisher(message).attempt
+        } yield {
+          consumer.receivedMessages shouldBe List(message)
+          consumer.returnedResults shouldBe List(Right(DeadLetter))
+          publishRes shouldBe 'right
+        }
       }
     }
   }
 
   test("A strict simulator client should fail to publish if a handler returns an exception") {
+    val consumer = StubHandlers.recordingHandler[IO, String](_ => IO.raiseError(exception))
     runAmqpTestStrict { client =>
-      for {
-        _          <- client.declare(declarations)
-        consumer   <- IO.pure(StubHandlers.recordingHandler[IO, String](_ => IO.raiseError(exception)))
-        _          <- client.registerConsumerOf(queue, consumer)
-        publisher  <- IO(client.publisherOf[String](exchange, rk))
-        publishRes <- publisher(message).attempt
-      } yield {
-        consumer.receivedMessages shouldBe List(message)
-        consumer.returnedResults shouldBe List(Left(exception))
-        publishRes shouldBe 'left
+      (for {
+        _ <- Resource.liftF(client.declare(declarations))
+        _ <- client.registerConsumerOf(queue, consumer)
+
+      } yield ()).use { _ =>
+        for {
+          publisher  <- IO(client.publisherOf[String](exchange, rk))
+          publishRes <- publisher(message).attempt
+        } yield {
+          consumer.receivedMessages shouldBe List(message)
+          consumer.returnedResults shouldBe List(Left(exception))
+          publishRes shouldBe 'left
+        }
       }
+
     }
   }
 


### PR DESCRIPTION
Use a separate channel per consumer. 
Channels perform operations serially.
The impact of this is that consumer creation now returns a Resource which will manage channel allocation/deallocation