### PR TITLE
Converter of the message headers that converts Java representation to Scala might cause NPE's when used in Scala 2.11

### DIFF
--- a/core/src/main/scala/com/itv/bucky/MessagePropertiesConverters.scala
+++ b/core/src/main/scala/com/itv/bucky/MessagePropertiesConverters.scala
@@ -53,5 +53,5 @@ object MessagePropertiesConverters {
   private def toJInt(value: Option[Int]): Integer                  = value.fold[Integer](null)(value => value)
   private def toJString(value: Option[String]): String             = value.fold[String](null)(identity)
   private def toJDate(value: Option[Date]): Date                   = value.fold[Date](null)(identity)
-  private def priorityOf(properties: BasicProperties): Option[Int] = Option(properties.getPriority)
+  private def priorityOf(properties: BasicProperties): Option[Int] = Option[Integer](properties.getPriority).map(_.toInt)
 }

--- a/core/src/test/scala/com/itv/bucky/MessagePropertiesConvertersTest.scala
+++ b/core/src/test/scala/com/itv/bucky/MessagePropertiesConvertersTest.scala
@@ -1,0 +1,79 @@
+package com.itv.bucky
+
+import java.util.Date
+
+import com.itv.bucky.consume.DeliveryMode
+import com.itv.bucky.publish.{ContentEncoding, ContentType, MessageProperties}
+import com.rabbitmq.client.AMQP.BasicProperties
+import org.scalatest.{FunSuite, Matchers}
+
+import scala.collection.JavaConverters._
+
+class MessagePropertiesConvertersTest extends FunSuite with Matchers {
+
+  test("should be able to convert minimal basic properties to message properties") {
+
+    val basicProperties: BasicProperties             = new BasicProperties()
+    val messageProperties: publish.MessageProperties = MessagePropertiesConverters.apply(basicProperties)
+
+    messageProperties shouldBe publish.MessageProperties(
+      contentType = None,
+      contentEncoding = None,
+      headers = Map.empty,
+      deliveryMode = None,
+      priority = None,
+      correlationId = None,
+      replyTo = None,
+      expiration = None,
+      messageId = None,
+      timestamp = None,
+      messageType = None,
+      userId = None,
+      appId = None,
+      clusterId = None
+    )
+
+  }
+
+  test("should be able to convert full basic properties to message properties") {
+
+    val date    = new Date()
+    val headers = Map[String, AnyRef]("h1" -> "v1", "h2" -> "XXX")
+
+    val fullBasicProperties = new BasicProperties(
+      "application/xml",
+      "UTF-8",
+      headers.asJava,
+      1,
+      2,
+      "correlationId",
+      "replyTo",
+      "10s",
+      "ABC",
+      date,
+      "type",
+      "userId",
+      "appId",
+      "clusterId"
+    )
+
+    MessagePropertiesConverters(fullBasicProperties) shouldBe MessageProperties(
+      contentType = Some(ContentType("application/xml")),
+      contentEncoding = Some(ContentEncoding("UTF-8")),
+      headers = headers,
+      deliveryMode = Some(DeliveryMode.nonPersistent),
+      priority = Some(2),
+      correlationId = Some("correlationId"),
+      replyTo = Some("replyTo"),
+      expiration = Some("10s"),
+      messageId = Some("ABC"),
+      timestamp = Some(date),
+      messageType = Some("type"),
+      userId = Some("userId"),
+      appId = Some("appId"),
+      clusterId = Some("clusterId")
+    )
+
+  }
+
+}


### PR DESCRIPTION
Here is possible stack trace:
java.lang.NullPointerException: null
	at scala.Predef$.Integer2int(Predef.scala:362)
	at com.itv.bucky.MessagePropertiesConverters$.priorityOf(MessagePropertiesConverters.scala:56)
	at com.itv.bucky.MessagePropertiesConverters$.apply(MessagePropertiesConverters.scala:21)
	at com.itv.bucky.consume.Consumer$.deliveryFrom(Consumer.scala:11)
	at com.itv.bucky.Channel$$anon$1$$anon$2$$anonfun$handleDelivery$1$$anonfun$apply$14.apply(Channel.scala:128)
	at com.itv.bucky.Channel$$anon$1$$anon$2$$anonfun$handleDelivery$1$$anonfun$apply$14.apply(Channel.scala:128)

The root case is that preexisting implementaton of priorityOf function implicitly converts Java Integer (nullable) into Scala Int
(non-nullable, thus failing to build) before even we start building Option instance from it.