### PR TITLE
No longer require a routing key to requeue/deadletter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -159,7 +159,7 @@ lazy val test = project
       "org.typelevel"              %% "cats-effect"    % catsEffectVersion,
       "com.rabbitmq"               % "amqp-client"     % amqpClientVersion,
       "com.typesafe"               % "config"          % typeSafeVersion % "it",
-      "ch.qos.logback"             % "logback-classic" % logbackVersion % "it"
+      "ch.qos.logback"             % "logback-classic" % logbackVersion % "test,it"
     )
   )
 

--- a/core/src/main/scala/com/itv/bucky/pattern/requeue/package.scala
+++ b/core/src/main/scala/com/itv/bucky/pattern/requeue/package.scala
@@ -16,11 +16,11 @@ package object requeue {
 
   def requeueDeclarations(queueName: QueueName,
                           retryAfter: FiniteDuration = 5.minutes): Iterable[Declaration] = {
-    val dlxExchangeName: ExchangeName  = ExchangeName(s"${queueName.value}.dlx")
+    val dlxExchangeName: ExchangeName       = ExchangeName(s"${queueName.value}.dlx.v2")
     val deadLetterQueueName: QueueName      = QueueName(s"${queueName.value}.dlq")
     val requeueQueueName: QueueName         = QueueName(s"${queueName.value}.requeue")
-    val redeliverExchangeName: ExchangeName = ExchangeName(s"${queueName.value}.redeliver")
-    val requeueExchangeName: ExchangeName   = ExchangeName(s"${queueName.value}.requeue")
+    val redeliverExchangeName: ExchangeName = ExchangeName(s"${queueName.value}.redeliver.v2")
+    val requeueExchangeName: ExchangeName   = ExchangeName(s"${queueName.value}.requeue.v2")
 
     List(
       Queue(queueName).deadLetterExchange(dlxExchangeName),
@@ -54,7 +54,7 @@ package object requeue {
                   onHandlerException: RequeueConsumeAction = Requeue,
                   onRequeueExpiryAction: Delivery => F[ConsumeAction] = (_: Delivery) => F.point[ConsumeAction](DeadLetter),
                   prefetchCount: Int = defaultPreFetchCount): Resource[F, Unit] = {
-      val requeueExchange = ExchangeName(s"${queueName.value}.requeue")
+      val requeueExchange = ExchangeName(s"${queueName.value}.requeue.v2")
       val requeuePublish  = amqpClient.publisher()
       amqpClient.registerConsumer(queueName,
                                   RequeueTransformer(requeuePublish, requeueExchange, requeuePolicy, onHandlerException, onRequeueExpiryAction)(handler),

--- a/core/src/main/scala/com/itv/bucky/pattern/requeue/package.scala
+++ b/core/src/main/scala/com/itv/bucky/pattern/requeue/package.scala
@@ -16,11 +16,11 @@ package object requeue {
 
   def requeueDeclarations(queueName: QueueName,
                           retryAfter: FiniteDuration = 5.minutes): Iterable[Declaration] = {
-    val dlxExchangeName: ExchangeName       = ExchangeName(s"${queueName.value}.dlx.v2")
+    val dlxExchangeName: ExchangeName       = ExchangeName(s"${queueName.value}.dlx")
     val deadLetterQueueName: QueueName      = QueueName(s"${queueName.value}.dlq")
     val requeueQueueName: QueueName         = QueueName(s"${queueName.value}.requeue")
-    val redeliverExchangeName: ExchangeName = ExchangeName(s"${queueName.value}.redeliver.v2")
-    val requeueExchangeName: ExchangeName   = ExchangeName(s"${queueName.value}.requeue.v2")
+    val redeliverExchangeName: ExchangeName = ExchangeName(s"${queueName.value}.redeliver")
+    val requeueExchangeName: ExchangeName   = ExchangeName(s"${queueName.value}.requeue")
 
     List(
       Queue(queueName).deadLetterExchange(dlxExchangeName),
@@ -54,7 +54,7 @@ package object requeue {
                   onHandlerException: RequeueConsumeAction = Requeue,
                   onRequeueExpiryAction: Delivery => F[ConsumeAction] = (_: Delivery) => F.point[ConsumeAction](DeadLetter),
                   prefetchCount: Int = defaultPreFetchCount): Resource[F, Unit] = {
-      val requeueExchange = ExchangeName(s"${queueName.value}.requeue.v2")
+      val requeueExchange = ExchangeName(s"${queueName.value}.requeue")
       val requeuePublish  = amqpClient.publisher()
       amqpClient.registerConsumer(queueName,
                                   RequeueTransformer(requeuePublish, requeueExchange, requeuePolicy, onHandlerException, onRequeueExpiryAction)(handler),

--- a/core/src/main/scala/com/itv/bucky/wiring/Wiring.scala
+++ b/core/src/main/scala/com/itv/bucky/wiring/Wiring.scala
@@ -51,7 +51,7 @@ class Wiring[T](
   def publisherDeclarations: List[Declaration] =
     List(exchange)
   def consumerDeclarations: List[Declaration] =
-    List(exchangeWithBinding) ++ requeue.requeueDeclarations(queueName, routingKey)
+    List(exchangeWithBinding) ++ requeue.requeueDeclarations(queueName)
   def allDeclarations: List[Declaration] =
     (publisherDeclarations ++ consumerDeclarations).distinct
 

--- a/core/src/test/scala/com/itv/bucky/WiringTest.scala
+++ b/core/src/test/scala/com/itv/bucky/WiringTest.scala
@@ -77,7 +77,7 @@ class WiringTest extends FunSuite with StrictLogging {
         Exchange(ExchangeName("exchange"), Direct)
           .binding(RoutingKey("route") -> QueueName("queue"))
       ) ++
-        requeueDeclarations(QueueName("queue"), RoutingKey("route"))
+        requeueDeclarations(QueueName("queue"))
   }
 
 }

--- a/docs/consumer.md
+++ b/docs/consumer.md
@@ -54,7 +54,7 @@ object MyApp extends IOApp {
   val declarations = List(
     Queue(QueueName("queue-name")),
     Exchange(ExchangeName("exchange-name")).binding(RoutingKey("rk") -> QueueName("queue-name"))
-  )
+  ) ++ requeueDeclarations(QueueName("queue-name"))
 
   class MyHandler extends RequeueHandler[IO, Message] {
     override def apply(m: Message): IO[RequeueConsumeAction] = IO(Ack)

--- a/example/src/main/scala/com/itv/bucky/example/requeue/RequeueConsumer.scala
+++ b/example/src/main/scala/com/itv/bucky/example/requeue/RequeueConsumer.scala
@@ -19,7 +19,7 @@ object RequeueConsumer extends IOApp with StrictLogging {
 
   object Declarations {
     val queue = Queue(QueueName(s"requeue_string-1"))
-    val all: Iterable[Declaration] = basicRequeueDeclarations(queue.name, retryAfter = 1.second)
+    val all: Iterable[Declaration] = requeueDeclarations(queue.name, retryAfter = 1.second)
   }
 
   val config: Config = ConfigFactory.load("bucky")

--- a/test/src/it/scala/RequeueIntegrationTest.scala
+++ b/test/src/it/scala/RequeueIntegrationTest.scala
@@ -52,7 +52,7 @@ class RequeueIntegrationTest extends FunSuite with Eventually with IntegrationPa
 
     val declarations = List(
       Exchange(exchangeName).binding(routingKey -> queueName)
-    ) ++ requeue.requeueDeclarations(queueName, routingKey)
+    ) ++ requeue.requeueDeclarations(queueName)
 
     AmqpClient[IO](config).use { client =>
       val handler = StubHandlers.requeueRequeueHandler[IO, Delivery]

--- a/test/src/it/scala/RequeueWithExpiryActionIntegrationTest.scala
+++ b/test/src/it/scala/RequeueWithExpiryActionIntegrationTest.scala
@@ -58,7 +58,7 @@ class RequeueWithExpiryActionIntegrationTest extends FunSuite with Eventually wi
 
     val declarations = List(
       Exchange(exchangeName).binding(routingKey -> queueName)
-    ) ++ requeue.requeueDeclarations(queueName, routingKey)
+    ) ++ requeue.requeueDeclarations(queueName)
 
     AmqpClient[IO](config).use { client =>
       val handler = new RecordingRequeueHandler[IO, String](Kleisli(handlerAction).andThen(_ => IO(Requeue)).run)

--- a/test/src/it/scala/ShutdownTimeoutTest.scala
+++ b/test/src/it/scala/ShutdownTimeoutTest.scala
@@ -46,7 +46,7 @@ class ShutdownTimeoutTest extends FunSuite with Eventually with IntegrationPatie
     val exchangeName                                              = ExchangeName(UUID.randomUUID().toString)
     val routingKey                                                = RoutingKey(UUID.randomUUID().toString)
     val queueName                                                 = QueueName(UUID.randomUUID().toString)
-    val declarations                                              = List(Exchange(exchangeName).binding(routingKey -> queueName)) ++ requeue.requeueDeclarations(queueName, routingKey)
+    val declarations                                              = List(Exchange(exchangeName).binding(routingKey -> queueName)) ++ requeue.requeueDeclarations(queueName)
 
     AmqpClient[IO](config)
       .use { client =>

--- a/test/src/main/scala/com/itv/bucky/test/stubs/StubChannel.scala
+++ b/test/src/main/scala/com/itv/bucky/test/stubs/StubChannel.scala
@@ -18,6 +18,7 @@ import com.typesafe.scalalogging.StrictLogging
 import scala.language.higherKinds
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
+import com.itv.bucky.decl.Fanout
 
 abstract class StubChannel[F[_]](implicit F: ConcurrentEffect[F]) extends Channel[F] with StrictLogging {
   var publishSeq: Long                                                        = 0L
@@ -48,6 +49,7 @@ abstract class StubChannel[F[_]](implicit F: ConcurrentEffect[F]) extends Channe
 
     matchingExchanges.flatMap { ex =>
       if (ex.exchangeType == Headers) lookupQueuesForHeadersExchange(publishCommand)
+      else if (ex.exchangeType == Fanout) lookupQueuesForFanoutExchange(publishCommand)
       else lookupQueuesForRoutingKeyExchange(publishCommand)
     }.toList
   }
@@ -122,6 +124,13 @@ abstract class StubChannel[F[_]](implicit F: ConcurrentEffect[F]) extends Channe
 
     (bindings
       .filter(binding => binding.exchangeName == publishCommand.exchange && headersMatch(binding.arguments))
+      .map(_.queueName)
+      .toList)
+  }
+
+  private def lookupQueuesForFanoutExchange(publishCommand: PublishCommand): List[QueueName] = {
+    (bindings
+      .filter(binding => binding.exchangeName == publishCommand.exchange)
       .map(_.queueName)
       .toList)
   }

--- a/test/src/test/scala/com/itv/bucky/test/PublishConsumeTest.scala
+++ b/test/src/test/scala/com/itv/bucky/test/PublishConsumeTest.scala
@@ -378,7 +378,7 @@ class PublishConsumeTest extends FunSuite with IOAmqpClientTest with Eventually 
       val rk    = RoutingKey("ark")
 
       val declarations =
-        List(Queue(queue), Exchange(exchange).binding(rk -> queue)) ++ com.itv.bucky.pattern.requeue.requeueDeclarations(queue, rk)
+        List(Queue(queue), Exchange(exchange).binding(rk -> queue)) ++ com.itv.bucky.pattern.requeue.requeueDeclarations(queue)
 
       val requeueHandler = StubHandlers.ackHandler[IO, String]
 


### PR DESCRIPTION
In our team, we've recently come across issues where we have multiple routing keys/bindings going to one queue. This causes an issue with requeue declarations as they are often declared with a single routing key. That means if a message deadletters with a different routing key we end up losing messages :scream: 

So what I propose is removing the requirement of a routing key when setting up the requeue declarations. Instead of using a direct exchange for the requeue/deadletter exchanges, it could use a fanout exchange. If a message is going to one of these exchanges, we know where it is destined for without a routing key. The fanout exchange will ignore the routing key and just forward to the relevant queue.

The only issue is the migration of this. I see two possible options:
1. Take the hit on upgrade and require the user upgrading to delete the existing exchanges before the service with upgraded bucky starts
2. Rename the requeue/deadletter exchanges so they can be swapped to, and the existing ones deleted after.

Does this sound like a good idea? Any suggestions?