### PR TITLE
Ease fanout migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,17 @@
 
 (under construction: [v1 docs](https://github.com/ITV/bucky/tree/v1.4.5), [v2 docs](https://io.itv.com/bucky/))
     
+# Migrating to 2.0.0-M28 and above
 
+Version 2.0.0-28 introduced a change to default all dead letter exchanges to be Fanout by default. Previously these were Direct.
+The reason for this change is due to an issue when multiple queues are bound to the same routing key on the same exchange and vice versa.
+When a handler dead letters a message it will be lost into the Ether as the broker can't work out where to send it.
 
+To upgrade:
+ - The signature of `requeueDeclarations` has changed. Try to use the new default dlx exchange type where possible.
+ - If changing the dlx type, delete the `.requeue`, `.dlx` and `.redeliver` exchanges manually before deploying your newly upgraded service.
+ If you don't do this, the service will fail to start complaining about mismatching Exchange types.
+
+If you really must continue using a Direct exchange:
+ - If using Wiring, use `setDeadLetterExchangeType = ExchangeType.Direct`
+ - If using requeueDeclarations, you will need to pass in `dlxType=Direct`.

--- a/build.sbt
+++ b/build.sbt
@@ -170,7 +170,7 @@ lazy val test = project
       "org.typelevel"              %% "cats-effect"    % catsEffectVersion,
       "com.rabbitmq"               % "amqp-client"     % amqpClientVersion,
       "com.typesafe"               % "config"          % typeSafeVersion % "it",
-      "ch.qos.logback"             % "logback-classic" % logbackVersion % "it"
+      "ch.qos.logback"             % "logback-classic" % logbackVersion % "test,it"
     )
   )
 

--- a/core/src/main/scala/com/itv/bucky/pattern/requeue/package.scala
+++ b/core/src/main/scala/com/itv/bucky/pattern/requeue/package.scala
@@ -16,11 +16,11 @@ package object requeue {
 
   def requeueDeclarations(queueName: QueueName,
                           retryAfter: FiniteDuration = 5.minutes): Iterable[Declaration] = {
-    val dlxExchangeName: ExchangeName  = ExchangeName(s"${queueName.value}.dlx")
+    val dlxExchangeName: ExchangeName       = ExchangeName(s"${queueName.value}.dlx.v2")
     val deadLetterQueueName: QueueName      = QueueName(s"${queueName.value}.dlq")
     val requeueQueueName: QueueName         = QueueName(s"${queueName.value}.requeue")
-    val redeliverExchangeName: ExchangeName = ExchangeName(s"${queueName.value}.redeliver")
-    val requeueExchangeName: ExchangeName   = ExchangeName(s"${queueName.value}.requeue")
+    val redeliverExchangeName: ExchangeName = ExchangeName(s"${queueName.value}.redeliver.v2")
+    val requeueExchangeName: ExchangeName   = ExchangeName(s"${queueName.value}.requeue.v2")
 
     List(
       Queue(queueName).deadLetterExchange(dlxExchangeName),
@@ -54,7 +54,7 @@ package object requeue {
                   onHandlerException: RequeueConsumeAction = Requeue,
                   onRequeueExpiryAction: Delivery => F[ConsumeAction] = (_: Delivery) => F.point[ConsumeAction](DeadLetter),
                   prefetchCount: Int = defaultPreFetchCount): Resource[F, Unit] = {
-      val requeueExchange = ExchangeName(s"${queueName.value}.requeue")
+      val requeueExchange = ExchangeName(s"${queueName.value}.requeue.v2")
       val requeuePublish  = amqpClient.publisher()
       amqpClient.registerConsumer(queueName,
                                   RequeueTransformer(requeuePublish, requeueExchange, requeuePolicy, onHandlerException, onRequeueExpiryAction)(handler),

--- a/core/src/main/scala/com/itv/bucky/pattern/requeue/package.scala
+++ b/core/src/main/scala/com/itv/bucky/pattern/requeue/package.scala
@@ -16,11 +16,11 @@ package object requeue {
 
   def requeueDeclarations(queueName: QueueName,
                           retryAfter: FiniteDuration = 5.minutes): Iterable[Declaration] = {
-    val dlxExchangeName: ExchangeName       = ExchangeName(s"${queueName.value}.dlx.v2")
+    val dlxExchangeName: ExchangeName       = ExchangeName(s"${queueName.value}.dlx")
     val deadLetterQueueName: QueueName      = QueueName(s"${queueName.value}.dlq")
     val requeueQueueName: QueueName         = QueueName(s"${queueName.value}.requeue")
-    val redeliverExchangeName: ExchangeName = ExchangeName(s"${queueName.value}.redeliver.v2")
-    val requeueExchangeName: ExchangeName   = ExchangeName(s"${queueName.value}.requeue.v2")
+    val redeliverExchangeName: ExchangeName = ExchangeName(s"${queueName.value}.redeliver")
+    val requeueExchangeName: ExchangeName   = ExchangeName(s"${queueName.value}.requeue")
 
     List(
       Queue(queueName).deadLetterExchange(dlxExchangeName),
@@ -54,7 +54,7 @@ package object requeue {
                   onHandlerException: RequeueConsumeAction = Requeue,
                   onRequeueExpiryAction: Delivery => F[ConsumeAction] = (_: Delivery) => F.point[ConsumeAction](DeadLetter),
                   prefetchCount: Int = defaultPreFetchCount): Resource[F, Unit] = {
-      val requeueExchange = ExchangeName(s"${queueName.value}.requeue.v2")
+      val requeueExchange = ExchangeName(s"${queueName.value}.requeue")
       val requeuePublish  = amqpClient.publisher()
       amqpClient.registerConsumer(queueName,
                                   RequeueTransformer(requeuePublish, requeueExchange, requeuePolicy, onHandlerException, onRequeueExpiryAction)(handler),

--- a/core/src/main/scala/com/itv/bucky/wiring/Wiring.scala
+++ b/core/src/main/scala/com/itv/bucky/wiring/Wiring.scala
@@ -45,7 +45,7 @@ class Wiring[T](
   def prefetchCount: Int =
     setPrefetchCount.getOrElse(1)
   lazy val dlxType: ExchangeType =
-    setDeadLetterExchangeType.getOrElse(Direct)
+    setDeadLetterExchangeType.getOrElse(Fanout)
   def dlxRoutingKey: RoutingKey =
     if (dlxType == Fanout) RoutingKey("-") else routingKey
 
@@ -56,7 +56,7 @@ class Wiring[T](
   def publisherDeclarations: List[Declaration] =
     List(exchange)
   def consumerDeclarations: List[Declaration] =
-    List(exchangeWithBinding) ++ requeue.requeueDeclarations(queueName, dlxRoutingKey, Exchange(ExchangeName(s"${queueName.value}.dlx"), exchangeType = dlxType))
+    List(exchangeWithBinding) ++ requeue.requeueDeclarations(queueName, dlxRoutingKey, Some(ExchangeName(s"${queueName.value}.dlx")), dlxType)
   def allDeclarations: List[Declaration] =
     (publisherDeclarations ++ consumerDeclarations).distinct
 

--- a/core/src/main/scala/com/itv/bucky/wiring/Wiring.scala
+++ b/core/src/main/scala/com/itv/bucky/wiring/Wiring.scala
@@ -45,7 +45,7 @@ class Wiring[T](
   def prefetchCount: Int =
     setPrefetchCount.getOrElse(1)
   lazy val dlxType: ExchangeType =
-    setDeadLetterExchangeType.getOrElse(Fanout)
+    setDeadLetterExchangeType.getOrElse(Direct)
   def dlxRoutingKey: RoutingKey =
     if (dlxType == Fanout) RoutingKey("-") else routingKey
 
@@ -56,7 +56,7 @@ class Wiring[T](
   def publisherDeclarations: List[Declaration] =
     List(exchange)
   def consumerDeclarations: List[Declaration] =
-    List(exchangeWithBinding) ++ requeue.requeueDeclarations(queueName, dlxType = dlxType, dlxRoutingKey)
+    List(exchangeWithBinding) ++ requeue.requeueDeclarations(queueName, dlxRoutingKey, Exchange(ExchangeName(s"${queueName.value}.dlx"), exchangeType = dlxType))
   def allDeclarations: List[Declaration] =
     (publisherDeclarations ++ consumerDeclarations).distinct
 

--- a/core/src/main/scala/com/itv/bucky/wiring/Wiring.scala
+++ b/core/src/main/scala/com/itv/bucky/wiring/Wiring.scala
@@ -51,7 +51,7 @@ class Wiring[T](
   def publisherDeclarations: List[Declaration] =
     List(exchange)
   def consumerDeclarations: List[Declaration] =
-    List(exchangeWithBinding) ++ requeue.requeueDeclarations(queueName, routingKey)
+    List(exchangeWithBinding) ++ requeue.requeueDeclarations(queueName)
   def allDeclarations: List[Declaration] =
     (publisherDeclarations ++ consumerDeclarations).distinct
 

--- a/core/src/test/scala/com/itv/bucky/WiringTest.scala
+++ b/core/src/test/scala/com/itv/bucky/WiringTest.scala
@@ -77,7 +77,7 @@ class WiringTest extends AnyFunSuite with StrictLogging {
         Exchange(ExchangeName("exchange"), Direct)
           .binding(RoutingKey("route") -> QueueName("queue"))
       ) ++
-        requeueDeclarations(QueueName("queue"), RoutingKey("route"))
+        requeueDeclarations(QueueName("queue"))
   }
 
 }

--- a/core/src/test/scala/com/itv/bucky/WiringTest.scala
+++ b/core/src/test/scala/com/itv/bucky/WiringTest.scala
@@ -71,7 +71,7 @@ class WiringTest extends AnyFunSuite with StrictLogging {
   test("it should create declarations for publishers") {
     CustomTestWiring.publisherDeclarations shouldBe List(Exchange(ExchangeName("exchange")))
   }
-  test("it should create declarations for consumers with requeue exchange type of Direct by default") {
+  test("it should create declarations for consumers with requeue exchange type of Fanout by default") {
     val routingKey = RoutingKey("route")
     val queueName = QueueName("queue")
 
@@ -80,11 +80,11 @@ class WiringTest extends AnyFunSuite with StrictLogging {
         Exchange(ExchangeName("exchange"), Direct)
           .binding(routingKey -> queueName)
       ) ++
-        requeueDeclarations(QueueName("queue"), routingKey, Exchange(ExchangeName(s"${queueName.value}.dlx"), exchangeType = Direct))
+        requeueDeclarations(QueueName("queue"), RoutingKey("-"), Some(ExchangeName(s"${queueName.value}.dlx")), Fanout)
   }
   test("it should allow specification of dead letter exchange type") {
     val routingKey = RoutingKey("route")
-    val dlxType = Fanout
+    val dlxType = Direct
     val queueName = QueueName("queue")
     object CustomTestWiring
       extends Wiring[String](
@@ -102,7 +102,7 @@ class WiringTest extends AnyFunSuite with StrictLogging {
         Exchange(ExchangeName("exchange"), Direct)
           .binding(routingKey -> QueueName("queue"))
       ) ++
-        requeueDeclarations(QueueName("queue"), RoutingKey("-"), Exchange(ExchangeName(s"${queueName.value}.dlx"), exchangeType = dlxType))
+        requeueDeclarations(QueueName("queue"), routingKey, Some(ExchangeName(s"${queueName.value}.dlx")), dlxType)
   }
 
 }

--- a/docs/consumer.md
+++ b/docs/consumer.md
@@ -54,7 +54,7 @@ object MyApp extends IOApp {
   val declarations = List(
     Queue(QueueName("queue-name")),
     Exchange(ExchangeName("exchange-name")).binding(RoutingKey("rk") -> QueueName("queue-name"))
-  )
+  ) ++ requeueDeclarations(QueueName("queue-name"))
 
   class MyHandler extends RequeueHandler[IO, Message] {
     override def apply(m: Message): IO[RequeueConsumeAction] = IO(Ack)

--- a/example/src/main/scala/com/itv/bucky/example/requeue/RequeueConsumer.scala
+++ b/example/src/main/scala/com/itv/bucky/example/requeue/RequeueConsumer.scala
@@ -19,7 +19,7 @@ object RequeueConsumer extends IOApp with StrictLogging {
 
   object Declarations {
     val queue = Queue(QueueName(s"requeue_string-1"))
-    val all: Iterable[Declaration] = requeueDeclarations(queue.name, RoutingKey(queue.name.value), Exchange(ExchangeName(s"${queue.name.value}.dlx"), exchangeType = Direct), retryAfter = 1.second)
+    val all: Iterable[Declaration] = requeueDeclarations(queue.name, RoutingKey(queue.name.value), Some(ExchangeName(s"${queue.name.value}.dlx")), Direct, retryAfter = 1.second)
   }
 
   val config: Config = ConfigFactory.load("bucky")

--- a/example/src/main/scala/com/itv/bucky/example/requeue/RequeueConsumer.scala
+++ b/example/src/main/scala/com/itv/bucky/example/requeue/RequeueConsumer.scala
@@ -19,7 +19,7 @@ object RequeueConsumer extends IOApp with StrictLogging {
 
   object Declarations {
     val queue = Queue(QueueName(s"requeue_string-1"))
-    val all: Iterable[Declaration] = basicRequeueDeclarations(queue.name, retryAfter = 1.second)
+    val all: Iterable[Declaration] = requeueDeclarations(queue.name, retryAfter = 1.second)
   }
 
   val config: Config = ConfigFactory.load("bucky")

--- a/example/src/main/scala/com/itv/bucky/example/requeue/RequeueConsumer.scala
+++ b/example/src/main/scala/com/itv/bucky/example/requeue/RequeueConsumer.scala
@@ -19,7 +19,7 @@ object RequeueConsumer extends IOApp with StrictLogging {
 
   object Declarations {
     val queue = Queue(QueueName(s"requeue_string-1"))
-    val all: Iterable[Declaration] = requeueDeclarations(queue.name, retryAfter = 1.second)
+    val all: Iterable[Declaration] = requeueDeclarations(queue.name, Direct, RoutingKey(queue.name.value), retryAfter = 1.second)
   }
 
   val config: Config = ConfigFactory.load("bucky")

--- a/example/src/main/scala/com/itv/bucky/example/requeue/RequeueConsumer.scala
+++ b/example/src/main/scala/com/itv/bucky/example/requeue/RequeueConsumer.scala
@@ -19,7 +19,7 @@ object RequeueConsumer extends IOApp with StrictLogging {
 
   object Declarations {
     val queue = Queue(QueueName(s"requeue_string-1"))
-    val all: Iterable[Declaration] = requeueDeclarations(queue.name, Direct, RoutingKey(queue.name.value), retryAfter = 1.second)
+    val all: Iterable[Declaration] = requeueDeclarations(queue.name, RoutingKey(queue.name.value), Exchange(ExchangeName(s"${queue.name.value}.dlx"), exchangeType = Direct), retryAfter = 1.second)
   }
 
   val config: Config = ConfigFactory.load("bucky")

--- a/test/src/it/scala/RequeueIntegrationTest.scala
+++ b/test/src/it/scala/RequeueIntegrationTest.scala
@@ -7,7 +7,7 @@ import com.itv.bucky.PayloadMarshaller.StringPayloadMarshaller
 import com.itv.bucky.Unmarshaller.StringPayloadUnmarshaller
 import com.itv.bucky.consume._
 import com.itv.bucky.publish._
-import com.itv.bucky.decl.{Direct, Exchange, Queue}
+import com.itv.bucky.decl.{Exchange, Queue}
 import com.itv.bucky.pattern.requeue
 import com.itv.bucky.pattern.requeue.RequeuePolicy
 import com.itv.bucky.test.StubHandlers
@@ -51,7 +51,7 @@ class RequeueIntegrationTest extends AnyFunSuite with Eventually with Integratio
 
     val declarations = List(
       Exchange(exchangeName).binding(routingKey -> queueName)
-    ) ++ requeue.requeueDeclarations(queueName, Direct, routingKey)
+    ) ++ requeue.requeueDeclarations(queueName, routingKey)
 
     AmqpClient[IO](config).use { client =>
       val handler = StubHandlers.requeueRequeueHandler[IO, Delivery]

--- a/test/src/it/scala/RequeueIntegrationTest.scala
+++ b/test/src/it/scala/RequeueIntegrationTest.scala
@@ -53,7 +53,7 @@ class RequeueIntegrationTest extends AnyFunSuite with Eventually with Integratio
 
     val declarations = List(
       Exchange(exchangeName).binding(routingKey -> queueName)
-    ) ++ requeue.requeueDeclarations(queueName, routingKey)
+    ) ++ requeue.requeueDeclarations(queueName)
 
     AmqpClient[IO](config).use { client =>
       val handler = StubHandlers.requeueRequeueHandler[IO, Delivery]

--- a/test/src/it/scala/RequeueIntegrationTest.scala
+++ b/test/src/it/scala/RequeueIntegrationTest.scala
@@ -7,20 +7,18 @@ import com.itv.bucky.PayloadMarshaller.StringPayloadMarshaller
 import com.itv.bucky.Unmarshaller.StringPayloadUnmarshaller
 import com.itv.bucky.consume._
 import com.itv.bucky.publish._
-import com.itv.bucky.decl.{Exchange, Queue}
+import com.itv.bucky.decl.{Direct, Exchange, Queue}
 import com.itv.bucky.pattern.requeue
 import com.itv.bucky.pattern.requeue.RequeuePolicy
 import com.itv.bucky.test.StubHandlers
 import com.itv.bucky.test.stubs.{RecordingHandler, RecordingRequeueHandler}
 import com.typesafe.config.ConfigFactory
-
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext
-
 import scala.language.higherKinds
 
 class RequeueIntegrationTest extends AnyFunSuite with Eventually with IntegrationPatience {
@@ -53,7 +51,7 @@ class RequeueIntegrationTest extends AnyFunSuite with Eventually with Integratio
 
     val declarations = List(
       Exchange(exchangeName).binding(routingKey -> queueName)
-    ) ++ requeue.requeueDeclarations(queueName)
+    ) ++ requeue.requeueDeclarations(queueName, Direct, routingKey)
 
     AmqpClient[IO](config).use { client =>
       val handler = StubHandlers.requeueRequeueHandler[IO, Delivery]

--- a/test/src/it/scala/RequeueWithExpiryActionIntegrationTest.scala
+++ b/test/src/it/scala/RequeueWithExpiryActionIntegrationTest.scala
@@ -8,17 +8,15 @@ import com.itv.bucky.PayloadMarshaller.StringPayloadMarshaller
 import com.itv.bucky.Unmarshaller.StringPayloadUnmarshaller
 import com.itv.bucky._
 import com.itv.bucky.consume._
-import com.itv.bucky.decl.Exchange
+import com.itv.bucky.decl.{Direct, Exchange}
 import com.itv.bucky.pattern.requeue
 import com.itv.bucky.pattern.requeue.RequeuePolicy
 import com.itv.bucky.publish._
 import com.itv.bucky.test.StubHandlers
 import com.itv.bucky.test.stubs.{RecordingHandler, RecordingRequeueHandler}
 import com.typesafe.config.ConfigFactory
-
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers._
-
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 
 import scala.collection.mutable.ListBuffer
@@ -60,7 +58,7 @@ class RequeueWithExpiryActionIntegrationTest extends AnyFunSuite with Eventually
 
     val declarations = List(
       Exchange(exchangeName).binding(routingKey -> queueName)
-    ) ++ requeue.requeueDeclarations(queueName)
+    ) ++ requeue.requeueDeclarations(queueName, Direct, routingKey)
 
     AmqpClient[IO](config).use { client =>
       val handler = new RecordingRequeueHandler[IO, String](Kleisli(handlerAction).andThen(_ => IO(Requeue)).run)

--- a/test/src/it/scala/RequeueWithExpiryActionIntegrationTest.scala
+++ b/test/src/it/scala/RequeueWithExpiryActionIntegrationTest.scala
@@ -60,7 +60,7 @@ class RequeueWithExpiryActionIntegrationTest extends AnyFunSuite with Eventually
 
     val declarations = List(
       Exchange(exchangeName).binding(routingKey -> queueName)
-    ) ++ requeue.requeueDeclarations(queueName, routingKey)
+    ) ++ requeue.requeueDeclarations(queueName)
 
     AmqpClient[IO](config).use { client =>
       val handler = new RecordingRequeueHandler[IO, String](Kleisli(handlerAction).andThen(_ => IO(Requeue)).run)

--- a/test/src/it/scala/RequeueWithExpiryActionIntegrationTest.scala
+++ b/test/src/it/scala/RequeueWithExpiryActionIntegrationTest.scala
@@ -8,7 +8,7 @@ import com.itv.bucky.PayloadMarshaller.StringPayloadMarshaller
 import com.itv.bucky.Unmarshaller.StringPayloadUnmarshaller
 import com.itv.bucky._
 import com.itv.bucky.consume._
-import com.itv.bucky.decl.{Direct, Exchange}
+import com.itv.bucky.decl.Exchange
 import com.itv.bucky.pattern.requeue
 import com.itv.bucky.pattern.requeue.RequeuePolicy
 import com.itv.bucky.publish._
@@ -58,7 +58,7 @@ class RequeueWithExpiryActionIntegrationTest extends AnyFunSuite with Eventually
 
     val declarations = List(
       Exchange(exchangeName).binding(routingKey -> queueName)
-    ) ++ requeue.requeueDeclarations(queueName, Direct, routingKey)
+    ) ++ requeue.requeueDeclarations(queueName, routingKey)
 
     AmqpClient[IO](config).use { client =>
       val handler = new RecordingRequeueHandler[IO, String](Kleisli(handlerAction).andThen(_ => IO(Requeue)).run)

--- a/test/src/it/scala/ShutdownTimeoutTest.scala
+++ b/test/src/it/scala/ShutdownTimeoutTest.scala
@@ -7,7 +7,7 @@ import com.itv.bucky.PayloadMarshaller.StringPayloadMarshaller
 import com.itv.bucky.Unmarshaller.StringPayloadUnmarshaller
 import com.itv.bucky._
 import com.itv.bucky.consume._
-import com.itv.bucky.decl.{Direct, Exchange}
+import com.itv.bucky.decl.Exchange
 import com.itv.bucky.pattern.requeue
 import com.itv.bucky.pattern.requeue.RequeuePolicy
 import com.itv.bucky.publish._
@@ -46,7 +46,7 @@ class ShutdownTimeoutTest extends AnyFunSuite with Eventually with IntegrationPa
     val exchangeName                                              = ExchangeName(UUID.randomUUID().toString)
     val routingKey                                                = RoutingKey(UUID.randomUUID().toString)
     val queueName                                                 = QueueName(UUID.randomUUID().toString)
-    val declarations                                              = List(Exchange(exchangeName).binding(routingKey -> queueName)) ++ requeue.requeueDeclarations(queueName, Direct, routingKey)
+    val declarations                                              = List(Exchange(exchangeName).binding(routingKey -> queueName)) ++ requeue.requeueDeclarations(queueName, routingKey)
 
     AmqpClient[IO](config)
       .use { client =>

--- a/test/src/it/scala/ShutdownTimeoutTest.scala
+++ b/test/src/it/scala/ShutdownTimeoutTest.scala
@@ -48,7 +48,7 @@ class ShutdownTimeoutTest extends AnyFunSuite with Eventually with IntegrationPa
     val exchangeName                                              = ExchangeName(UUID.randomUUID().toString)
     val routingKey                                                = RoutingKey(UUID.randomUUID().toString)
     val queueName                                                 = QueueName(UUID.randomUUID().toString)
-    val declarations                                              = List(Exchange(exchangeName).binding(routingKey -> queueName)) ++ requeue.requeueDeclarations(queueName, routingKey)
+    val declarations                                              = List(Exchange(exchangeName).binding(routingKey -> queueName)) ++ requeue.requeueDeclarations(queueName)
 
     AmqpClient[IO](config)
       .use { client =>

--- a/test/src/it/scala/ShutdownTimeoutTest.scala
+++ b/test/src/it/scala/ShutdownTimeoutTest.scala
@@ -7,17 +7,15 @@ import com.itv.bucky.PayloadMarshaller.StringPayloadMarshaller
 import com.itv.bucky.Unmarshaller.StringPayloadUnmarshaller
 import com.itv.bucky._
 import com.itv.bucky.consume._
-import com.itv.bucky.decl.Exchange
+import com.itv.bucky.decl.{Direct, Exchange}
 import com.itv.bucky.pattern.requeue
 import com.itv.bucky.pattern.requeue.RequeuePolicy
 import com.itv.bucky.publish._
 import com.itv.bucky.test.StubHandlers
 import com.itv.bucky.test.stubs.{RecordingHandler, RecordingRequeueHandler}
 import com.typesafe.config.ConfigFactory
-
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers._
-
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 
 import scala.concurrent.ExecutionContext
@@ -48,7 +46,7 @@ class ShutdownTimeoutTest extends AnyFunSuite with Eventually with IntegrationPa
     val exchangeName                                              = ExchangeName(UUID.randomUUID().toString)
     val routingKey                                                = RoutingKey(UUID.randomUUID().toString)
     val queueName                                                 = QueueName(UUID.randomUUID().toString)
-    val declarations                                              = List(Exchange(exchangeName).binding(routingKey -> queueName)) ++ requeue.requeueDeclarations(queueName)
+    val declarations                                              = List(Exchange(exchangeName).binding(routingKey -> queueName)) ++ requeue.requeueDeclarations(queueName, Direct, routingKey)
 
     AmqpClient[IO](config)
       .use { client =>

--- a/test/src/test/scala/com/itv/bucky/test/PublishConsumeTest.scala
+++ b/test/src/test/scala/com/itv/bucky/test/PublishConsumeTest.scala
@@ -379,7 +379,7 @@ class PublishConsumeTest extends AnyFunSuite with IOAmqpClientTest with Eventual
       val rk    = RoutingKey("ark")
 
       val declarations =
-        List(Queue(queue), Exchange(exchange).binding(rk -> queue)) ++ com.itv.bucky.pattern.requeue.requeueDeclarations(queue)
+        List(Queue(queue), Exchange(exchange).binding(rk -> queue)) ++ com.itv.bucky.pattern.requeue.requeueDeclarations(queue, Direct, rk)
 
       val requeueHandler = StubHandlers.ackHandler[IO, String]
 

--- a/test/src/test/scala/com/itv/bucky/test/PublishConsumeTest.scala
+++ b/test/src/test/scala/com/itv/bucky/test/PublishConsumeTest.scala
@@ -379,7 +379,7 @@ class PublishConsumeTest extends AnyFunSuite with IOAmqpClientTest with Eventual
       val rk    = RoutingKey("ark")
 
       val declarations =
-        List(Queue(queue), Exchange(exchange).binding(rk -> queue)) ++ com.itv.bucky.pattern.requeue.requeueDeclarations(queue, rk)
+        List(Queue(queue), Exchange(exchange).binding(rk -> queue)) ++ com.itv.bucky.pattern.requeue.requeueDeclarations(queue)
 
       val requeueHandler = StubHandlers.ackHandler[IO, String]
 

--- a/test/src/test/scala/com/itv/bucky/test/PublishConsumeTest.scala
+++ b/test/src/test/scala/com/itv/bucky/test/PublishConsumeTest.scala
@@ -379,7 +379,7 @@ class PublishConsumeTest extends AnyFunSuite with IOAmqpClientTest with Eventual
       val rk    = RoutingKey("ark")
 
       val declarations =
-        List(Queue(queue), Exchange(exchange).binding(rk -> queue)) ++ com.itv.bucky.pattern.requeue.requeueDeclarations(queue, Direct, rk)
+        List(Queue(queue), Exchange(exchange).binding(rk -> queue)) ++ com.itv.bucky.pattern.requeue.requeueDeclarations(queue, rk)
 
       val requeueHandler = StubHandlers.ackHandler[IO, String]
 


### PR DESCRIPTION
This PR builds upon the work done by @andrewgee here: https://github.com/ITV/bucky/pull/58

The exchange type is now paramaterised to allow the user to specify what they require.
To use this version...
1) If using Wiring
 - Add the `setDeadLetterExchangeType = Some(dlxType)` to configure the dlx type. Default = DIRECT.

2) If not using Wiring
- Set the dead letter exchange type in the App to whatever you require.
- If a Fanout type is required, pass in the routing key = `RoutingKey("-")` to `requeueDeclarations`

Note that this is done per binding, so you can have a mixture of dlx types.
If changing dlx type, the `.redeliver`, `.requeue` and `.dlx` exchanges will have to be manually deleted before the app will start. This can be done manually through the UI.