### PR TITLE
add timestamp to properties

### DIFF
--- a/core/src/main/scala/com/itv/bucky/decl/package.scala
+++ b/core/src/main/scala/com/itv/bucky/decl/package.scala
@@ -59,6 +59,6 @@ package object decl {
     def expires(value: FiniteDuration): Queue                 = argument("x-expires" -> Long.box(value.toMillis))
     def deadLetterExchange(exchangeName: ExchangeName): Queue = argument("x-dead-letter-exchange" -> exchangeName.value)
     def messageTTL(value: FiniteDuration): Queue              = argument("x-message-ttl" -> Long.box(value.toMillis))
+    def maxPriority(value: Option[Int]): Queue                = value.fold(this)(max => argument("x-max-priority" -> Long.box(max)))
   }
-
 }

--- a/core/src/main/scala/com/itv/bucky/pattern/requeue/package.scala
+++ b/core/src/main/scala/com/itv/bucky/pattern/requeue/package.scala
@@ -18,7 +18,8 @@ package object requeue {
                           routingKey: RoutingKey,
                           dlxName: Option[ExchangeName] = None,
                           dlxType: ExchangeType = Fanout,
-                          retryAfter: FiniteDuration = 5.minutes): Iterable[Declaration] = {
+                          retryAfter: FiniteDuration = 5.minutes,
+                          maxPriority: Option[Int] = None): Iterable[Declaration] = {
 
     val name = dlxName.getOrElse(ExchangeName(s"${queueName.value}.dlx"))
     val deadLetterQueueName: QueueName = QueueName(s"${queueName.value}.dlq")
@@ -27,7 +28,7 @@ package object requeue {
     val requeueExchangeName: ExchangeName = ExchangeName(s"${queueName.value}.requeue")
 
     List(
-      Queue(queueName).deadLetterExchange(name),
+      Queue(queueName).deadLetterExchange(name).maxPriority(maxPriority),
       Queue(deadLetterQueueName),
       Queue(requeueQueueName).deadLetterExchange(redeliverExchangeName).messageTTL(retryAfter),
       Exchange(name, exchangeType = dlxType).binding(routingKey -> deadLetterQueueName),

--- a/core/src/main/scala/com/itv/bucky/wiring/Wiring.scala
+++ b/core/src/main/scala/com/itv/bucky/wiring/Wiring.scala
@@ -26,7 +26,8 @@ class Wiring[T](
     setExchangeType: Option[ExchangeType] = None,
     setRequeuePolicy: Option[RequeuePolicy] = None,
     setPrefetchCount: Option[Int] = None,
-    setDeadLetterExchangeType: Option[ExchangeType] = None
+    setDeadLetterExchangeType: Option[ExchangeType] = None,
+    maxPriority: Option[Int] = None
 )(implicit
   val marshaller: PayloadMarshaller[T],
   val unmarshaller: PayloadUnmarshaller[T])
@@ -60,7 +61,8 @@ class Wiring[T](
                                                              dlxRoutingKey,
                                                              Some(ExchangeName(s"${queueName.value}.dlx")),
                                                              dlxType,
-                                                             requeueRetryAfter)
+                                                             requeueRetryAfter,
+                                                             maxPriority = maxPriority)
 
   //retain the default requeue ttl of 5 minutes, unless requeue policy requires a longer delay
   private def requeueRetryAfter: FiniteDuration = requeuePolicy.requeueAfter.max(5.minutes)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.0.3-SNAPSHOT"
+version in ThisBuild := "2.0.3"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.0.3"
+version in ThisBuild := "2.0.4-SNAPSHOT"


### PR DESCRIPTION
- Allow creation of priority queues Co-authored-by: Catia Ferreira <catia.ferreira@itv.com>
- Setting version to 2.0.3
- Setting version to 2.0.4-SNAPSHOT
